### PR TITLE
Adding ability for other HTTP methods

### DIFF
--- a/proxy_www/__init__.py
+++ b/proxy_www/__init__.py
@@ -14,7 +14,11 @@ __copyright__ = 'Copyright 2020 Lapis0875'
 __version__ = '1.0.0'
 
 from .implementation import www, http, https
+from .methods import GET, HEAD, POST, PUT,\
+                     DELETE, CONNECT, OPTIONS, TRACE, PATCH
 
-__all__ = ('www', 'http', 'https')
-
-
+__all__ = (
+    'www', 'http', 'https',
+    'GET', 'HEAD', 'POST', 'PUT',
+    'DELETE', 'CONNECT', 'OPTIONS', 'TRACE', 'PATCH',
+)

--- a/proxy_www/implementation.py
+++ b/proxy_www/implementation.py
@@ -50,15 +50,15 @@ class ClassProxyMeta(type):
 
         def __await__(self) -> aiohttp.ClientResponse:
             session = aiohttp.ClientSession()
-            resp = yield from session._request('GET', self.url).__await__()
+            resp = yield from session._request(self.method, self.url).__await__()
             yield from session.close().__await__()
-            logger.debug('{} -> GET : session closed? > {}'.format(self.url, session.closed))
+            logger.debug('{} -> {} : session closed? > {}'.format(self.url, self.method, session.closed))
             return resp
 
         __await__.__name__ = '{}.__await__'.format(clsname)
 
         def __repr__(self) -> str:
-            return 'ClassProxy(class={}, url={})'.format(self.__class__.__name__, self.url)
+            return 'ClassProxy(class={}, url={}, method={})'.format(self.__class__.__name__, self.url, self.method)
 
         __repr__.__name__ = '{}.__repr__'.format(clsname)
 
@@ -67,7 +67,8 @@ class ClassProxyMeta(type):
             '__truediv__': __truediv__,
             '__getattr__': __getattr__,
             '__init__': __init__,
-            '__repr__': __repr__
+            '__repr__': __repr__,
+            'method': 'GET'
         })
 
         logger.debug('Updated attrs for ClassProxy {}:'.format(clsname))
@@ -109,7 +110,7 @@ class www(metaclass=ClassProxyMeta):
         raise NotImplementedError('Currently, sync request using ClassProxy.__call__ is WIP. Sorry for inconvenience :(')
 
     def __sync_req__(self):
-        task_name: str = 'www.Future({} -> GET)'.format(self.url)
+        task_name: str = 'www.Future({} -> {})'.format(self.url, self.method)
         task: asyncio.Task = asyncio.create_task(self.__await__(), name=task_name)
         task.add_done_callback(partial(print, task_name))
         # result = next(future.__await__())

--- a/proxy_www/methods.py
+++ b/proxy_www/methods.py
@@ -1,0 +1,43 @@
+import typing
+from .implementation import www, http, https
+
+
+def __httpmethod__class_getitem__(cls, proxy_obj: typing.Union[www, http, https]):
+    proxy_obj.method = cls.__name__
+    return proxy_obj
+
+
+class GET:
+    __class_getitem__ = __httpmethod__class_getitem__
+
+
+class HEAD:
+    __class_getitem__ = __httpmethod__class_getitem__
+
+
+class POST:
+    __class_getitem__ = __httpmethod__class_getitem__
+
+
+class PUT:
+    __class_getitem__ = __httpmethod__class_getitem__
+
+
+class DELETE:
+    __class_getitem__ = __httpmethod__class_getitem__
+
+
+class CONNECT:
+    __class_getitem__ = __httpmethod__class_getitem__
+
+
+class OPTIONS:
+    __class_getitem__ = __httpmethod__class_getitem__
+
+
+class TRACE:
+    __class_getitem__ = __httpmethod__class_getitem__
+
+
+class PATCH:
+    __class_getitem__ = __httpmethod__class_getitem__


### PR DESCRIPTION
This pull request adds ability to send request with another HTTP methods, such as POST, PUT, DELETE.  
Example:
```python
from proxy_www import *
import asyncio

# This will do GET request
asyncio.get_event_loop().run_until_complete(www.github.com)
asyncio.get_event_loop().run_until_complete(GET[www.github.com])

# This will do POST request
asyncio.get_event_loop().run_until_complete(POST[www.github.com])
```

![image](https://user-images.githubusercontent.com/12007455/117260955-90068b80-ae8a-11eb-942f-7c8fdf4830c2.png)
